### PR TITLE
Aligning coding standard between PHPStorm and PHP-CS-Fixer

### DIFF
--- a/CI/PHP-CS-Fixer/code-format.php_cs
+++ b/CI/PHP-CS-Fixer/code-format.php_cs
@@ -21,10 +21,8 @@ return PhpCsFixer\Config::create()
         'strict_param' => false,
         'cast_spaces' => true,
         'concat_space' => ['spacing' => 'one'],
-        'binary_operator_spaces' => true,
         'unary_operator_spaces' => true,
         'function_typehint_space' => true,
         'return_type_declaration' => ['space_before' => 'one'],
-        'whitespace_after_comma_in_array' => true,
 	])
 	->setFinder($finder);

--- a/CI/PHP-CS-Fixer/example/ILIAS_CodeStyle.xml
+++ b/CI/PHP-CS-Fixer/example/ILIAS_CodeStyle.xml
@@ -1,11 +1,10 @@
-<code_scheme name="Default (1)" version="173">
+<code_scheme name="ILIAS Code Style" version="173">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
       <option name="USE_TAB_CHARACTER" value="true" />
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="500" />
-  <option name="HTML_ATTRIBUTE_WRAP" value="0" />
   <HTMLCodeStyleSettings>
     <option name="HTML_ATTRIBUTE_WRAP" value="0" />
   </HTMLCodeStyleSettings>
@@ -26,6 +25,7 @@
     <option name="LOWER_CASE_NULL_CONST" value="true" />
     <option name="ELSE_IF_STYLE" value="COMBINE" />
     <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
+    <option name="SPACE_BEFORE_COLON_IN_RETURN_TYPE" value="true" />
   </PHPCodeStyleSettings>
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -102,6 +102,7 @@
     <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+    <option name="SPACE_AROUND_BITWISE_OPERATORS" value="false" />
     <option name="SPACE_AFTER_TYPE_CAST" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="5" />


### PR DESCRIPTION
Removes the rule for bitwise operators, so the alignment of equal can still be used.There seem currently no rule in PHP CS Fixer that can satisfy this behavior.

Also remove the `space after comma in array` rule because this differs between PHPStorm and the PHP CS Fixer
